### PR TITLE
perf(redis): use Pipelines

### DIFF
--- a/server/daemon/broker/redis/orchestrator.go
+++ b/server/daemon/broker/redis/orchestrator.go
@@ -21,7 +21,8 @@ type Broker struct {
 // Start will start the message broker and prepare it for testing.
 func (b *Broker) Start(host, port string) (interface{}, error) {
 	cmd := exec.Command("docker", "run", "-d", "-p",
-		fmt.Sprintf("%d:%d", redisPort, redisPort), redisDockerImg)
+		fmt.Sprintf("%d:%d", redisPort, redisPort), redisDockerImg,
+	)
 	containerID, err := cmd.Output()
 	if err != nil {
 		log.Printf("Failed to start container %s: %s", redisDockerImg, err.Error())


### PR DESCRIPTION
add Pipeline support for the publisher: this will increase performance
because publishing will require way less roundtrips to the Redis server.

change up the implementation of the publisher because the pipeline needs
to be flushed every so often. To test out how the pipeline api works, i
decided to go back to a single Producer goroutine that will spawn
another goroutine to flush the pipeline every N messages, where N is a
constant in the publisher function. I'll experiment some more to see if
more publishing goroutines will increase the Pro/Con performance is any
significant way.